### PR TITLE
switch from https to http

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -6,4 +6,4 @@ app.use(express.static("docs"))
 
 http
     .createServer(app)
-    .listen(8080, () => { console.log("started at http://trcevents.com:8080/test.html") });
+    .listen(8080, () => { console.log("started at http://trcevents.com:8080/test.html") })

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,14 +1,9 @@
 import express from "express"
-import * as https from "https"
-import * as fs from "fs"
+import * as http from "http"
 
 const app = express()
-
 app.use(express.static("docs"))
 
-const privateKey  = fs.readFileSync('secrets/trcevents.com-key.pem', 'utf8');
-const certificate = fs.readFileSync('secrets/trcevents.com.pem', 'utf8');
-
-https
-    .createServer({key: privateKey, cert: certificate}, app)
-    .listen(8443, () => { console.log("started at https://trcevents.com:8443/test.html") });
+http
+    .createServer(app)
+    .listen(8080, () => { console.log("started at http://trcevents.com:8080/test.html") });


### PR DESCRIPTION
I originally thought https was required for google maps integration, but I was wrong. https makes testing more difficult so I'm just going to remove it from the test server.